### PR TITLE
Add Dutch translation

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-version.md
+++ b/.github/ISSUE_TEMPLATE/new-version.md
@@ -13,6 +13,7 @@ A new English version of the Bioconductor Code of Conduct has been created (vers
 We kindly ask you to check those latest changes, and update the translation of the language that you maintain or contribute to.
 
 - [ ] Chinese: @XueyiDong
+- [ ] Dutch: @milanmlft
 - [ ] French: @kevinrue
 - [ ] German: @HelenaLC, @lmweber
 - [ ] Italian: @drighelli

--- a/_site.yml
+++ b/_site.yml
@@ -8,6 +8,8 @@ navbar:
       menu:
       - text: "Chinese, China"
         href: zh-CN.html
+      - text: "Dutch; Belgium, The Netherlands"
+        href: nl-BE.html
       - text: "English, United States"
         href: en-US.html
       - text: "French, France"

--- a/about.Rmd
+++ b/about.Rmd
@@ -10,6 +10,10 @@ This website provides community-contributed translations of the project-wide Cod
 
 - **Maintainer:** [Xueyi Dong](https://github.com/XueyiDong)
 
+#### `r paste(emo::ji('Belgium'), emo::ji('Netherlands'))` Dutch; Belgium, The Netherlands
+
+- **Maintainer:** [Milan Malfait](https://github.com/milanmlft)
+
 #### `r emo::ji("United_States")` English, United States
 
 - [BioC 2020 Organizing committee](https://bioc2020.bioconductor.org/organizers)

--- a/en-US.Rmd
+++ b/en-US.Rmd
@@ -105,3 +105,5 @@ This procedure is briefly summarized [here](https://bioconductor.github.io/CodeO
 * Kevin Rue-Albrecht kevinrue67@gmail.com  (until 2024) he/him [FR, EN] (CAB)
 * Charlotte Soneson charlottesoneson@gmail.com (until 2023) she/her [EN, SE] (TAB, European Bioconductor Society)
 * (Ombusdperson) Beatriz Serrano-Solano beatrizserrano.galaxy@gmail.com (Galaxy project) she/her [ES,EN]
+
+[1]: https://bioc2020.bioconductor.org/code_of_conduct

--- a/index.Rmd
+++ b/index.Rmd
@@ -31,6 +31,7 @@ To contribute new translations or updates, please read the
 |          Flag           | Language       | Version | Link               |
 | :---------------------: | :------------- | :-----: | :------------------|
 | `r emo::ji("China")` | Chinese, China | 1.0.2 | [zh-CN](zh-CN.html) |
+| `r paste(emo::ji('Belgium'), emo::ji('Netherlands'))` | Dutch; Belgium, The Netherlands | 1.1.0 | [nl-BE](nl-BE.html) |
 | `r emo::ji("United_States")` | **English, United States (original version)** | 1.1.0 | [en-US](en-US.html) |
 | `r emo::ji("France")` | French, France | 1.0.2 | [fr-FR](fr-FR.html) |
 | `r emo::ji("Germany")` | German, Germany | 1.0.2 | [de-DE](de-DE.html) |

--- a/nl-BE.Rmd
+++ b/nl-BE.Rmd
@@ -1,0 +1,110 @@
+---
+title: "`r paste(emo::ji('Belgium'), emo::ji('Netherlands'))` Projectbrede Gedragscode voor het Bioconductor project (Nederlands; België/Nederland)"
+---
+
+(Aangepast van de [Gedragscode voor het BioC 2020 congres][1], vertaald uit het [Engels](en-US.html)).
+
+# Gedragscode
+
+## Versie 1.1.0 (16 juli, 2022)
+
+_Initiële gedragscode, uitbreiding van voorgaande congres-specifieke documenten_
+
+De Bioconductor gemeenschapswaarden
+een open benadering van wetenschap die bevordert
+
+* delen van ideeën, code, software en expertise
+* samenwerking
+* diversiteit en inclusiviteit
+* een vriendelijke en gastvrije omgeving
+* bijdragen door de gemeenschap
+
+In lijn met deze waarden zet Bioconductor zich in om een gastvrije, ondersteunende, collegiale ervaring te bieden zonder intimidatie, bedreiging en pesten, ongeacht:
+
+* identiteit: geslacht, genderidentiteit en -expressie, seksuele geaardheid, handicap, uiterlijk, etniciteit, lichaamsgrootte, ras, leeftijd, religie, taal, enz.
+* intellectuele positie: benaderingen van data-analyse, software-voorkeuren, codeerstijl, wetenschappelijk perspectief, loopbaanfase, enz.
+
+Door deel te nemen aan deze community, stemt u ermee in zich niet in te laten met gedrag dat in strijd is met deze waarden tijdens een door Bioconductor gesponsord evenement (persoonlijk of virtueel, inclusief maar niet beperkt tot lezingen, workshops, postersessies, sociale activiteiten) of elektronische communicatiekanalen ( inclusief maar niet beperkt tot de "community-bioc" Slack, de ondersteuningssite, online forums, de beoordelingssite voor packages en communicatie via sociale media). Verder eisen we dat alle deelnemers identificeerbare accounts hebben op de online fora van Bioconductor. Accounts die zich hier niet aan houden na verzoek tot de-anonimisering kunnen worden verwijderd.
+
+We tolereren geen intimidatie of pesterijen van leden van de gemeenschap. Seksuele taal en beelden zijn niet gepast in presentaties, communicatie of op online locaties, inclusief chats.
+
+Elke persoon/personen die de Gedragscode overtreedt, kan naar goeddunken van de Gedragscodecommissie worden bestraft of tijdelijk of permanent worden verwijderd van een elektronisch platform of evenement.
+
+#### _Voorbeelden van onaanvaardbare intimidatie en pestgedrag_
+
+Intimidatie omvat, maar is niet beperkt tot:
+
+* Opmerkingen maken in chats, voor een publiek of persoonlijk, die een andere persoon kleineren of vernederen
+* Online seksuele afbeeldingen delen
+* Intimiderend fotograferen of opnemen
+* Aanhoudende verstoring van gesprekken of andere evenementen
+* Ongewenste seksuele aandacht
+* Pleiten voor, of aanmoedigen van, een van de bovenstaande gedragingen
+
+Bedreiging en pesten omvatten, maar zijn niet beperkt tot:
+
+* Agressief of brutaal gedrag
+* Het bespotten of beledigen van iemands intellect, werk, perspectief of vraag/opmerking
+* Verwijzen naar iemands geslacht, genderidentiteit en -expressie, seksuele geaardheid, handicap, fysieke verschijning, lichaamsgrootte, ras, leeftijd, religie of andere persoonlijke kenmerken in de context van een wetenschappelijke discussie
+* Iemand opzettelijk onwelkom laten voelen
+* "Trolling" gedrag (opzettelijk opruiende of beledigende berichten)
+* Aanhoudende off-topic berichten
+
+## Handhaving
+
+Iedereen die wordt gevraagd om te stoppen met intimiderend of pestend gedrag, wordt geacht dit onmiddellijk te doen.
+
+Als een persoon de Gedragscode schendt, behoudt de Gedragscodecommissie zich het recht om elke actie te ondernemen die zorgt voor een gastvrije omgeving voor alle leden van de gemeenschap. Dit omvat het waarschuwen van de vermeende overtreder of tijdelijke/permanente verwijdering van het evenement en/of elektronische platforms onder controle van Bioconductor.
+
+De gedragscodecommissie kan actie ondernemen om alles dat is ontworpen om, of met de duidelijke impact van, het verstoren van een evenement of elektronisch communicatieplatform of het vijandig maken van de omgeving voor een lid van de gemeenschap recht te zetten .
+
+We verwachten dat iedereen in de Bioconductor-gemeenschap de Gedragscode naleeft bij deelname aan Bioconductor-evenementen en online communicatieplatforms.
+
+## Aangifte
+Als iemand u of iemand anders een onveilig of onwelkom gevoel geeft, meld dit dan zo snel mogelijk. U kunt zowel anoniem als persoonlijk een melding doen. Alle meldingen worden beoordeeld door de Gedragscodecommissie en vertrouwelijk behandeld.
+
+#### _Elektronisch_
+
+U kunt een anonieme of niet-anonieme melding doen via de volgende link: https://forms.gle/gEWHBWnXvZbEdFsq5. Dit is een vrije tekstbox die wordt doorgestuurd naar de Gedragscodecommissie. U kunt ook een e-mail sturen naar de Gedragscodecommissie (code-of-conduct@bioconductor.org). Als u zich niet op uw gemak voelt om aan de Gedragscodecommissie als groep te rapporteren, kunt u contact opnemen met elk individueel commissielid via e-mail of een direct bericht op het "community-bioc" Slack-kanaal. Voeg indien mogelijk screenshots/kopieën van alle relevante elektronische gesprekken toe (u hoeft uw anonimiteit niet in gevaar te brengen!).
+
+We kunnen een anonieme melding niet rechtstreeks met u opnemen, maar we zullen deze volledig onderzoeken en alle nodige maatregelen nemen om herhaling te voorkomen.
+
+#### _Persoonlijk rapport (voor alle Bioconductor-evenementen: persoonlijk of virtueel)_
+
+U kunt een persoonlijke melding doen bij elk lid van de gedragscodecommissie dat aanwezig is op een evenement.
+
+Bij een persoonlijke melding zorgen wij ervoor dat u veilig bent en niet kunt worden afgeluisterd. We kunnen andere evenementenmedewerkers inschakelen om ervoor te zorgen dat uw melding op de juiste manier wordt beheerd. Als het veilig is, vragen we u om ons te vertellen wat er is gebeurd. Dit kan verontrustend zijn, maar we gaan er zo respectvol mogelijk mee om en u kunt iemand meenemen om u te ondersteunen. U wordt niet gevraagd om iemand te confronteren, en we zullen niemand vertellen wie u bent.
+
+Ons team helpt u graag om de relevante ondersteuning te krijgen (bijvoorbeeld hulp bij het contacteren van hotel-/locatiebeveiliging, lokale wetshandhaving, lokale ondersteuningsdiensten, het bieden van escortes of anderszins helpen om u veilig te voelen gedurende de duur van het evenement).
+
+We waarderen uw aanwezigheid en deelname aan Bioconductor-evenementen en in onze gemeenschap.
+
+#### _Ombudspersoon_
+
+We begrijpen dat u misschien wilt dat een persoon die geen familie is van Bioconductor toezicht houdt op uw conflictoplossing. Om dit te faciliteren zal de Gedragscodecommissie een ombudspersoon aanstellen uit een andere open source community dan leden van het Bioconductor-project. Hoewel ze niet de bevoegdheid hebben om besluiten van de Gedragscodecommissie vast te stellen, te wijzigen of opzij te zetten, kunnen ze leden van de gemeenschap helpen door advies, bemiddeling, coaching en doorverwijzing naar andere
+bronnen. De ombudspersoon is rechtstreeks bereikbaar via e-mail (zie hieronder) om te
+zorgen voor een vertrouwelijk, onpartijdig, informeel en onafhankelijk proces.
+
+#### _Incident procedure_
+
+De Gedragscodecommissie volgt een standaardprocedure voor het omgaan met conflicten.
+Deze procedure wordt [hier](https://bioconductor.github.io/CodeOfConduct/incident_response.html) kort samengevat.
+
+
+### Gedragscodecommissie
+
+* (Voorzitter) Saskia Freytag sas.freytag@gmail.com (tot 2023) zij/haar [EN, DE]
+* Yagoub Adam yagoub@alumni.usp.br (tot 2022) hij/hem [EN] (CAB)
+* Leonardo Collado-Torres lcolladotor@gmail.com (tot 2022) hij/hem [EN, ES]
+* Laurent Gatto laurent.gatto@gmail.com (tot 2023) hij/hem [FR, EN] (TAB, European Bioconductor Society)
+* Michael Love michaelisaiahlove@gmail.com (tot 2024) hij/hem [EN] (TAB)
+* Federico Marini fede.maro@gmail.com (tot 2024) hij/hem [EN, IT, DE]
+* Sowmya Parthiban sowmyaparthiban@gmail.com (tot 2024) zij/haar [EN, Tamil]
+* Anna Quaglieri anna.quaglieri16@gmail.com (tot 2024) zij/haar [EN, IT]
+* Johannes Rainer johannes.rainer@eurac.edu (tot 2023) hij/hem [EN, DE, IT] (CAB, European Bioconductor Society)
+* Lluís Revilla lluis.revilla@gmail.com (tot 2024) hij/hem [CAT, ES, EN]
+* Kevin Rue-Albrecht kevinrue67@gmail.com (tot 2024) hij/hem [FR, EN] (CAB)
+* Charlotte Soneson charlottesoneson@gmail.com (tot 2023) zij/haar [EN, SE] (TAB, European Bioconductor Society)
+* (Ombusdpersoon) Beatriz Serrano-Solano beatrizserrano.galaxy@gmail.com (Galaxy-project) zij/haar [ES,EN]
+
+[1]: https://bioc2020.bioconductor.org/code_of_conduct


### PR DESCRIPTION
Note I used the `nl-BE` code for "Belgian Dutch" (because that's where I'm from), but it's essentially the same as Dutch Dutch (from the Netherlands), which is why I used both countries and flags wherever relevant. Please let me know if that's OK :) (I just wanted to avoid any lingo-nationalistic clashes 🙃).

Incidentally, I also fixed a missing link in the original English version.